### PR TITLE
chore(bump): bump to latest ansible version compatible with python3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.18 AS builder
+FROM alpine:3.15 AS builder
 
-ARG VERSION_ANSIBLE="6.7.0"
+ARG VERSION_ANSIBLE="8.7.0"
 ARG VERSION_ANSIBLE_LINT="6.20.3"
-ARG VERSION_MOLECULE="3.6.1"
+ARG VERSION_MOLECULE="5.1.0"
 
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
@@ -16,12 +16,25 @@ RUN apk add --update-cache --no-cache \
 
 RUN pip install --upgrade --no-cache-dir pip
 
-RUN pip install --no-cache-dir \
+# Fix AttributeError: cython_sources https://stackoverflow.com/questions/77490435/attributeerror-cython-sources/77491847#77491847
+# RUN pip install --user --no-cache-dir "cython<3.0.0" wheel
+# RUN pip install --user --no-cache-dir "pyyaml==5.4.1" --no-build-isolation
+
+RUN pip install --user --no-cache-dir \
         ansible==${VERSION_ANSIBLE} \
         ansible-lint==${VERSION_ANSIBLE_LINT} \
-        molecule[docker]==${VERSION_MOLECULE}
+        molecule==${VERSION_MOLECULE} \
+        molecule-plugins[docker]
 
-FROM alpine:3.18
+# Prepare molecule workspace
+RUN mkdir /opt/workspace
+
+WORKDIR /opt/workspace
+
+CMD ["/bin/bash"]
+
+
+FROM alpine:3.15
 
 LABEL maintainer="Michael Maffait"
 LABEL org.opencontainers.image.source="https://github.com/Pandemonium1986/docker-alpine318"
@@ -40,10 +53,11 @@ RUN apk add --update-cache --no-cache \
         zsh
 
 # Copy from builder
-COPY --from=builder /usr/lib/python3.11/site-packages/ /usr/lib/python3.11/site-packages/
-COPY --from=builder /usr/bin/ansible*  /usr/bin/
-COPY --from=builder /usr/bin/molecule  /usr/bin/molecule
-COPY --from=builder /usr/bin/yamllint  /usr/bin/yamllint
+COPY --from=builder /usr/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/
+COPY --from=builder /root/.local/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/
+COPY --from=builder /root/.local/bin/ansible*  /usr/bin/
+COPY --from=builder /root/.local/bin/molecule  /usr/bin/molecule
+COPY --from=builder /root/.local/bin/yamllint  /usr/bin/yamllint
 
 # Prepare molecule workspace
 RUN mkdir /opt/workspace


### PR DESCRIPTION
bump ansible to 8.7.0
bump molecule to 5.1.0

<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/Pandemonium1986/.github/blob/main/CONTRIBUTING.md#coding-conventions
-->

<!-- markdownlint-disable-next-line -->
#### Describe the change
Bump to latest ansible version compatible with python3.9
* Bump ansible to 8.7.0
* Bump molecule to 5.1.0
* Keep ansible lint to 6.20.3
* Install molecule-plugins[docker]. 
<!-- A clear and concise description of what the pull request is. -->

#### Testing

See https://github.com/Pandemonium1986/ansible-role-init/actions/runs/7522410949/job/20474379748

<!-- In case a feature was added, how were tests performed? -->

#### Additional information

<!-- Add any other information -->
